### PR TITLE
Translation update

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2,5 +2,5 @@
 
 $lang['numberedHeading']         = 'Numbering headings';
 $lang['tocPosition']             = 'Position of TOC';
-$lang['tocPosition_o_dokuwiki']  = 'Dokuwiki';
+$lang['tocPosition_o_dokuwiki']  = 'DokuWiki';
 $lang['tocPosition_o_wikipedia'] = 'Wikipedia';

--- a/lang/ko/settings.php
+++ b/lang/ko/settings.php
@@ -3,4 +3,4 @@
 $lang['numberedHeading']         = '제목 수준에 번호를 붙힙니다.';
 $lang['tocPosition']             = '목차의 위치';
 $lang['tocPosition_o_dokuwiki']  = '도쿠위키 기본';
-$lang['tocPosition_o_wikipedia'] = '위키피디아 스타일';
+$lang['tocPosition_o_wikipedia'] = '위키백과 스타일';


### PR DESCRIPTION
- 'DokuWiki'에서, D와 W는 대문자입니다.
- 'Wikipedia'의 한국어 이름은 '위키백과'입니다.